### PR TITLE
Revert "Change decimals to 18"

### DIFF
--- a/contracts/Miner.sol
+++ b/contracts/Miner.sol
@@ -4,7 +4,7 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 contract Miner is ERC20, Ownable {
-    uint8 private constant DECIMALS = 18;
+    uint8 private constant DECIMALS = 4;
 
     address private _minter;
 

--- a/test/Issuance.test.js
+++ b/test/Issuance.test.js
@@ -13,7 +13,7 @@ contract("Issuance", (accounts) => {
 
     let miner, issuance;
 
-    const decimals = new BN("18");
+    const decimals = new BN("4");
     const supply = new BN("1000000").mul(new BN("10").pow(decimals));
 
     beforeEach(async () => {

--- a/test/Miner.test.js
+++ b/test/Miner.test.js
@@ -7,7 +7,7 @@ const Miner = artifacts.require("./Miner.sol");
 contract("Miner", accounts => {
     const symbol = "MINER";
     const name = "Miner";
-    const decimals = new BN("18");
+    const decimals = new BN("4");
     const initialSupply = new BN("0").mul(new BN("10").pow(decimals));
     const mintedSupply = new BN("1000000").mul(new BN("10").pow(decimals));
 

--- a/test/Treasury.test.js
+++ b/test/Treasury.test.js
@@ -19,7 +19,7 @@ contract("Treasury", (accounts) => {
     const ALICE = accounts[3];
     const BOB = accounts[4];
 
-    const decimals = new BN("18");
+    const decimals = new BN("4");
     const supply = new BN("1000000").mul(new BN("10").pow(decimals));
 
     const fastForward = 60*60*48;


### PR DESCRIPTION
Reverting branch.

Getting "Error: Number can only safely store up to 53 bits" on unit tests.

.toNumber() appears to be the culprit.

We need to change the tests to handle bignumber using:

expect(actual).to.be.bignumber.equal(expected);